### PR TITLE
added correct paths to dockerfile

### DIFF
--- a/modules/edgetoinfluxdb/Dockerfile
+++ b/modules/edgetoinfluxdb/Dockerfile
@@ -7,9 +7,9 @@ RUN npm install node-red-contrib-influxdb
 RUN npm install node-red-contrib-azure-iot-edge-kpm
 
 # Copy Node-RED project files into place
-COPY settings.js ./settings.js
-COPY flows_cred.json ./flows_cred.json
-COPY flows.json ./flows.json
+COPY settings.js /data/settings.js
+COPY flows_cred.json /data/flows_cred.json
+COPY flows.json /data/flows.json
 
 EXPOSE 1880/tcp
 


### PR DESCRIPTION
The default paths for the settings files should sit under the subfolder (data).

https://nodered.org/docs/getting-started/docker

These three files get copied to the base container folder and subsequently aren't picked up by node-red
