### PR TITLE
Specify versions of Influx + grafana

### DIFF
--- a/modules/grafana/Dockerfile
+++ b/modules/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:latest
+FROM grafana/grafana:6.7.5
 
 RUN grafana-cli plugins install grafana-influxdb-flux-datasource 5.4.1
 

--- a/modules/influxdb/Dockerfile
+++ b/modules/influxdb/Dockerfile
@@ -1,5 +1,5 @@
 # start with standard public influx image
-FROM influxdb
+FROM influxdb:1.7.11
 
 # copy in our database initialization script
 # creates telemetry database and sets retention policy


### PR DESCRIPTION
Newer versions of these components have broken the dashboards so explicitly specifying versions of grafana and influxDB to pull. Specifically, the versions that have been tested to work are: 
- Grafana 6.7.5
- InfluxDB 1.7.11